### PR TITLE
Asl2 license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2014 Kenshoo.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Development Instuctions
 License
 -------
 
-FreeMarker-Online is licensed under the Apache License, Version 2.0. See LICENSE.txt for detils.
+FreeMarker-Online is licensed under the Apache License, Version 2.0. See LICENSE.txt for details.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Development Instuctions
 * For running the software from a command line just hit "java -jar build/libs/freemarker-online-0.1.undef.jar server  src/main/resources/freemarker-online.yml"
 
 
+License
+-------
+
+FreeMarker-Online is licensed under the Apache License, Version 2.0. See LICENSE.txt for detils.

--- a/src/main/java/com/kenshoo/freemarker/dropwizard/ApplicationStartup.java
+++ b/src/main/java/com/kenshoo/freemarker/dropwizard/ApplicationStartup.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2011 Kenshoo.com
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.dropwizard;
 
 import com.berico.fallwizard.SpringConfiguration;

--- a/src/main/java/com/kenshoo/freemarker/healthchecks/MyProjectHealthCheck.java
+++ b/src/main/java/com/kenshoo/freemarker/healthchecks/MyProjectHealthCheck.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.healthchecks;
 
 import com.yammer.metrics.core.HealthCheck;

--- a/src/main/java/com/kenshoo/freemarker/resources/FreeMarkerOnlineResource.java
+++ b/src/main/java/com/kenshoo/freemarker/resources/FreeMarkerOnlineResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.resources;
 
 import java.text.MessageFormat;

--- a/src/main/java/com/kenshoo/freemarker/services/FreeMarkerService.java
+++ b/src/main/java/com/kenshoo/freemarker/services/FreeMarkerService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.services;
 
 import java.io.StringWriter;

--- a/src/main/java/com/kenshoo/freemarker/services/FreeMarkerServiceException.java
+++ b/src/main/java/com/kenshoo/freemarker/services/FreeMarkerServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.services;
 
 /**

--- a/src/main/java/com/kenshoo/freemarker/services/FreeMarkerServiceResponse.java
+++ b/src/main/java/com/kenshoo/freemarker/services/FreeMarkerServiceResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.services;
 
 /**

--- a/src/main/java/com/kenshoo/freemarker/util/DataModelParser.java
+++ b/src/main/java/com/kenshoo/freemarker/util/DataModelParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import java.io.IOException;

--- a/src/main/java/com/kenshoo/freemarker/util/DataModelParsingException.java
+++ b/src/main/java/com/kenshoo/freemarker/util/DataModelParsingException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import java.util.TimeZone;

--- a/src/main/java/com/kenshoo/freemarker/util/ExceptionUtils.java
+++ b/src/main/java/com/kenshoo/freemarker/util/ExceptionUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import freemarker.core.ParseException;

--- a/src/main/java/com/kenshoo/freemarker/util/LengthLimitExceededException.java
+++ b/src/main/java/com/kenshoo/freemarker/util/LengthLimitExceededException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import java.io.IOException;

--- a/src/main/java/com/kenshoo/freemarker/util/LengthLimitedWriter.java
+++ b/src/main/java/com/kenshoo/freemarker/util/LengthLimitedWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import java.io.FilterWriter;

--- a/src/main/java/com/kenshoo/freemarker/view/FreeMarkerOnlineView.java
+++ b/src/main/java/com/kenshoo/freemarker/view/FreeMarkerOnlineView.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.view;
 
 import java.nio.charset.Charset;

--- a/src/main/java/com/kenshoo/freemarker/view/FreeMarkerOnlineViewResultType.java
+++ b/src/main/java/com/kenshoo/freemarker/view/FreeMarkerOnlineViewResultType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.view;
 
 public enum FreeMarkerOnlineViewResultType {

--- a/src/main/java/freemarker/core/FreeMarkerInternalsAccessor.java
+++ b/src/main/java/freemarker/core/FreeMarkerInternalsAccessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package freemarker.core;
 
 import freemarker.core.ThreadInterruptionSupportTemplatePostProcessor.TemplateProcessingThreadInterruptedException;

--- a/src/test/java/com/kenshoo/freemarker/platform/DropWizardServiceTest.java
+++ b/src/test/java/com/kenshoo/freemarker/platform/DropWizardServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.platform;
 
 import com.google.common.io.Resources;

--- a/src/test/java/com/kenshoo/freemarker/platform/YamlPropertiesPersister.java
+++ b/src/test/java/com/kenshoo/freemarker/platform/YamlPropertiesPersister.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.platform;
 
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;

--- a/src/test/java/com/kenshoo/freemarker/resources/FreeMarkerOnlineResourceTest.java
+++ b/src/test/java/com/kenshoo/freemarker/resources/FreeMarkerOnlineResourceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.resources;
 
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/com/kenshoo/freemarker/services/FreeMarkerServiceResponseBuilderTest.java
+++ b/src/test/java/com/kenshoo/freemarker/services/FreeMarkerServiceResponseBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.services;
 
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/com/kenshoo/freemarker/services/FreeMarkerServiceTest.java
+++ b/src/test/java/com/kenshoo/freemarker/services/FreeMarkerServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.services;
 
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/com/kenshoo/freemarker/util/DataModelParserTest.java
+++ b/src/test/java/com/kenshoo/freemarker/util/DataModelParserTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/com/kenshoo/freemarker/util/LengthLimitedWriterTest.java
+++ b/src/test/java/com/kenshoo/freemarker/util/LengthLimitedWriterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.util;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/kenshoo/freemarker/view/FreeMarkerOnlineViewTest.java
+++ b/src/test/java/com/kenshoo/freemarker/view/FreeMarkerOnlineViewTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.view;
 
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/com/kenshoo/freemarker/webdriver/WebDriverTest.java
+++ b/src/test/java/com/kenshoo/freemarker/webdriver/WebDriverTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Kenshoo.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kenshoo.freemarker.webdriver;
 
 import com.google.common.io.Resources;


### PR DESCRIPTION
I have found an already existing ASL 2 license comment on
/src/main/java/com/kenshoo/freemarker/dropwizard/ApplicationStartup.java,
which said "Copyright 2011 Kenshoo.com". So assuming that that's what
you used to use (instead of, like, "Kenshoo, Ltd."), I went ahead with
that. However, I have changed the date to 2014. Tell me if any
adjustment is needed.