### PR TITLE
Fixed result textarea bug when template output contains <td>/<tr>/<th>

### DIFF
--- a/src/main/resources/assets/js/script.js
+++ b/src/main/resources/assets/js/script.js
@@ -48,15 +48,15 @@ $( document).ready(function(){
                     if(data.problems) {
                         var error = data.problems.dataModel ? data.problems.dataModel : data.problems.template;
                         $("#result").addClass("error");
-                        $("#result").html(error);
+                        $("#result").val(error);
                     }
                     else {
                         $("#result").removeClass("error");
-                        $("#result").html(data.result);
+                        $("#result").val(data.result);
                     }
                 })
                 .fail(function(data){
-                    $("#result").html(data.responseJSON.errorCode + ": " + data.responseJSON.errorDescription);
+                    $("#result").val(data.responseJSON.errorCode + ": " + data.responseJSON.errorDescription);
                     $("#result").addClass("error");
                 }).always(function(data){
                     $(".resultContainer").show();


### PR DESCRIPTION
Fixed bug where the result textarea was shown as empty if the template output has contained <tr>, <td> or <th>.