### PR TITLE
Update to FreeMarker 2.3.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compile libraries.freemarker
     compile libraries.jackson_databind
     compile libraries.commonLangs
+    compile libraries.findBugs
 
     testCompile libraries.selenium_java
     testCompile libraries.jersey_grrizle

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,8 +39,9 @@ project.libraries = [
         jersey_grrizle: 'com.sun.jersey.jersey-test-framework:jersey-test-framework-grizzly:1.17',
 
         // Others
-        freemarker: 'org.freemarker:freemarker:2.3.23',
+        freemarker: 'org.freemarker:freemarker:2.3.24-incubating',
         jackson_databind: "com.fasterxml.jackson.core:jackson-databind:$jackson_version",
-        commonLangs: "org.apache.commons:commons-lang3:3.3.2"
+        commonLangs: "org.apache.commons:commons-lang3:3.3.2",
+        findBugs: "com.google.code.findbugs:annotations:3.0.0"
 
 ]

--- a/src/main/resources/view/freemarker-online.ftl
+++ b/src/main/resources/view/freemarker-online.ftl
@@ -48,7 +48,7 @@
 
         <div class="content">
             <form id="templateAndModelForm" method="post" class="pure-form pure-form-stacked">
-                <label for="template">Template <span class="faint">(FreeMarker ${freeMarkerVersion})</span></label>
+                <label for="template">Template <span class="faint">(Apache FreeMarker ${freeMarkerVersion})</span></label>
                 <textarea id="template" name="template" class="pure-input-1 source-code"
                         placeholder="Enter template, like: Hello ${r'${user}'}!"
                 >${template}</textarea>


### PR DESCRIPTION
Update to FreeMarker 2.3.24. The FindBugs dependency is needed because javac under Gradle warns about the class-scope SupressFBWarnings annotations inside freemarker.jar, and we use -Werror switch too so the warn would make the build fail. (Interestingly, Maven builds don't care about those annotations, and they are indeed ignorable.)