### PR TITLE
Upgraded FreeMarker to 2.3.25. Removed findBugs dependency, as the re…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     compile libraries.freemarker
     compile libraries.jackson_databind
     compile libraries.commonLangs
-    compile libraries.findBugs
 
     testCompile libraries.selenium_java
     testCompile libraries.jersey_grrizle

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,9 +39,8 @@ project.libraries = [
         jersey_grrizle: 'com.sun.jersey.jersey-test-framework:jersey-test-framework-grizzly:1.17',
 
         // Others
-        freemarker: 'org.freemarker:freemarker:2.3.24-incubating',
+        freemarker: 'org.freemarker:freemarker:2.3.25-incubating',
         jackson_databind: "com.fasterxml.jackson.core:jackson-databind:$jackson_version",
-        commonLangs: "org.apache.commons:commons-lang3:3.3.2",
-        findBugs: "com.google.code.findbugs:annotations:3.0.0"
+        commonLangs: "org.apache.commons:commons-lang3:3.3.2"
 
 ]


### PR DESCRIPTION
…lated issue with Gradle (a compiler warning) was worked around in 2.3.25.